### PR TITLE
[YM-20397] Update Android Button SDK dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.yoti.mobile.android.sdk:yoti-button-sdk:1.1.3"
+    implementation "com.yoti.mobile.android.sdk:yoti-button-sdk:1.2.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-button",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A <YotiButton /> component for React Native",
     "main": "YotiButton.js",
     "license": "MIT",


### PR DESCRIPTION
An update to the Android Button SDK has recently be done (https://github.com/getyoti/android-sdk-button/releases/tag/v1.2.1), here we are simply upgrading the dependency for the Android module.