### PR TITLE
Extract token from callback URL on Android

### DIFF
--- a/android/src/main/java/com/yoti/reactnative/RNYotiButtonPackage.java
+++ b/android/src/main/java/com/yoti/reactnative/RNYotiButtonPackage.java
@@ -1,6 +1,9 @@
 package com.yoti.reactnative;
 
+import android.content.IntentFilter;
+
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -8,17 +11,41 @@ import com.facebook.react.uimanager.ViewManager;
 import java.util.Collections;
 import java.util.List;
 
-public class RNYotiButtonPackage implements ReactPackage {
+public class RNYotiButtonPackage implements ReactPackage, LifecycleEventListener {
+    private ShareAttributesResultBroadcastReceiver mBroadcastReceiver;
+    private String mYotiCallback;
+    private String mYotiBackendCallback;
+    private ReactApplicationContext context;
 
-  @Override
-  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return Collections.<ViewManager>singletonList(new RNYotiButtonViewManager());
-  }
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        context = reactContext;
+        mBroadcastReceiver = new ShareAttributesResultBroadcastReceiver();
+        mYotiCallback = context.getPackageName() + ".YOTI_CALLBACK";
+        mYotiBackendCallback = context.getPackageName() + ".BACKEND_CALLBACK";
+        context.getApplicationContext().registerReceiver(mBroadcastReceiver, new IntentFilter(mYotiCallback));
+        context.getApplicationContext().registerReceiver(mBroadcastReceiver, new IntentFilter(mYotiBackendCallback));
+        context.addLifecycleEventListener((LifecycleEventListener) this);
 
-  @Override
-  public List<NativeModule> createNativeModules(
-                              ReactApplicationContext reactContext) {
-     return Collections.emptyList();
-  }
+        return Collections.<ViewManager>singletonList(new RNYotiButtonViewManager());
+    }
 
+    @Override
+    public List<NativeModule> createNativeModules(
+            ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void onHostResume() {
+    }
+
+    @Override
+    public void onHostPause() {
+    }
+
+    @Override
+    public void onHostDestroy() {
+        context.unregisterReceiver(mBroadcastReceiver);
+    }
 }

--- a/android/src/main/java/com/yoti/reactnative/RNYotiButtonView.java
+++ b/android/src/main/java/com/yoti/reactnative/RNYotiButtonView.java
@@ -1,9 +1,7 @@
 package com.yoti.reactnative;
 
-import android.content.IntentFilter;
 import android.text.TextUtils;
 import android.widget.LinearLayout;
-import com.yoti.reactnative.R;
 
 import com.yoti.mobile.android.sdk.YotiSDK;
 import com.yoti.mobile.android.sdk.YotiSDKButton;
@@ -22,30 +20,29 @@ import javax.annotation.Nullable;
 public class RNYotiButtonView extends LinearLayout {
     private ThemedReactContext context;
     private YotiSDKButton mButton;
-    private ShareAttributesResultBroadcastReceiver mBroadcastReceiver;
-    private String mYotiCallback;
-    private String mYotiBackendCallback;
     private String mClientSDKID;
     private String mScenarioID;
     private String mUseCaseId;
+    private String mYotiCallback;
+    private String mYotiBackendCallback;
 
     RNYotiButtonView(ThemedReactContext context) {
         super(context);
         this.context = context;
         inflate(context, R.layout.yotibutton, this);
         mButton = findViewById(R.id.RNYotiButton);
-        mBroadcastReceiver = new ShareAttributesResultBroadcastReceiver();
         mYotiCallback = context.getPackageName() + ".YOTI_CALLBACK";
         mYotiBackendCallback = context.getPackageName() + ".BACKEND_CALLBACK";
-        context.getApplicationContext().registerReceiver(mBroadcastReceiver, new IntentFilter(mYotiCallback));
-        context.getApplicationContext().registerReceiver(mBroadcastReceiver, new IntentFilter(mYotiBackendCallback));
 
         YotiSDK.enableSDKLogging(true);
 
         mButton.setOnYotiButtonClickListener(new YotiSDKButton.OnYotiButtonClickListener() {
             @Override
             public void onStartScenario() {
-                sendEvent("onStartScenario", null);
+                WritableMap params = Arguments.createMap();
+                params.putString("useCaseID", mUseCaseId);
+                params.putString("scenarioID", mScenarioID);
+                sendEvent("onStartScenario", params);
             }
 
             @Override
@@ -59,14 +56,20 @@ public class RNYotiButtonView extends LinearLayout {
         mButton.setOnYotiAppNotInstalledListener(new YotiSDKButton.OnYotiAppNotInstalledListener() {
             @Override
             public void onYotiAppNotInstalledError(YotiSDKNoYotiAppException cause) {
-                sendEvent("onYotiAppNotInstalled", null);
+                WritableMap params = Arguments.createMap();
+                params.putString("useCaseID", mUseCaseId);
+                params.putString("scenarioID", mScenarioID);
+                sendEvent("onYotiAppNotInstalled", params);
             }
         });
 
         mButton.setOnYotiCalledListener(new YotiSDKButton.OnYotiCalledListener() {
             @Override
             public void onYotiCalled() {
-                sendEvent("onOpenYotiApp", null);
+                WritableMap params = Arguments.createMap();
+                params.putString("useCaseID", mUseCaseId);
+                params.putString("scenarioID", mScenarioID);
+                sendEvent("onOpenYotiApp", params);
             }
         });
     }
@@ -86,7 +89,6 @@ public class RNYotiButtonView extends LinearLayout {
         addScenarioIfPropsReady();
     }
 
-
     public void setClientSDKID(String clientSDKID) {
         mClientSDKID = clientSDKID;
         addScenarioIfPropsReady();
@@ -100,8 +102,8 @@ public class RNYotiButtonView extends LinearLayout {
     private void addScenarioIfPropsReady() {
         if (
                 TextUtils.isEmpty(mUseCaseId) ||
-                TextUtils.isEmpty(mClientSDKID) ||
-                TextUtils.isEmpty(mScenarioID)
+                        TextUtils.isEmpty(mClientSDKID) ||
+                        TextUtils.isEmpty(mScenarioID)
         ) {
             return;
         }

--- a/android/src/main/java/com/yoti/reactnative/RNYotiButtonViewManager.java
+++ b/android/src/main/java/com/yoti/reactnative/RNYotiButtonViewManager.java
@@ -5,35 +5,35 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
 public class RNYotiButtonViewManager extends SimpleViewManager<RNYotiButtonView> {
-  private static final String REACT_CLASS = "RNYotiButton";
+    private static final String REACT_CLASS = "RNYotiButton";
 
-  @Override
-  public String getName() {
-    return REACT_CLASS;
-  }
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
 
-  @Override
-  public RNYotiButtonView createViewInstance(ThemedReactContext context) {
-    return new RNYotiButtonView(context);
-  }
+    @Override
+    public RNYotiButtonView createViewInstance(ThemedReactContext context) {
+        return new RNYotiButtonView(context);
+    }
 
-  @ReactProp(name = "title")
-  public void setTitle(RNYotiButtonView view, String title) {
-    view.setTitle(title);
-  }
+    @ReactProp(name = "title")
+    public void setTitle(RNYotiButtonView view, String title) {
+        view.setTitle(title);
+    }
 
-  @ReactProp(name = "useCaseID")
-  public void setUseCaseID(RNYotiButtonView view, String useCaseId) {
-    view.setUseCaseId(useCaseId);
-  }
+    @ReactProp(name = "useCaseID")
+    public void setUseCaseID(RNYotiButtonView view, String useCaseId) {
+        view.setUseCaseId(useCaseId);
+    }
 
-  @ReactProp(name = "clientSDKID")
-  public void setClientSDKID(RNYotiButtonView view, String clientSDKID) {
-    view.setClientSDKID(clientSDKID);
-  }
+    @ReactProp(name = "clientSDKID")
+    public void setClientSDKID(RNYotiButtonView view, String clientSDKID) {
+        view.setClientSDKID(clientSDKID);
+    }
 
-  @ReactProp(name = "scenarioID")
-  public void setScenarioID(RNYotiButtonView view, String scenarioID) {
-    view.setScenarioID(scenarioID);
-  }
+    @ReactProp(name = "scenarioID")
+    public void setScenarioID(RNYotiButtonView view, String scenarioID) {
+        view.setScenarioID(scenarioID);
+    }
 }

--- a/android/src/main/java/com/yoti/reactnative/ShareAttributesResultBroadcastReceiver.java
+++ b/android/src/main/java/com/yoti/reactnative/ShareAttributesResultBroadcastReceiver.java
@@ -10,6 +10,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.yoti.mobile.android.sdk.AbstractShareAttributesBroadcastReceiver;
 
 import javax.annotation.Nullable;
+
 import com.facebook.react.ReactInstanceManager;
 
 public class ShareAttributesResultBroadcastReceiver extends AbstractShareAttributesBroadcastReceiver {
@@ -41,15 +42,17 @@ public class ShareAttributesResultBroadcastReceiver extends AbstractShareAttribu
         mContext.startActivity(intent);
 
         WritableMap params = Arguments.createMap();
-        params.putString("useCaseId", useCaseId);
+        params.putString("useCaseID", useCaseId);
         sendEvent("onShareFailed", params);
     }
 
     @Override
-    public void onCallbackSuccess(String useCaseId, byte[] response) {}
+    public void onCallbackSuccess(String useCaseId, byte[] response) {
+    }
 
     @Override
-    public void onCallbackError(String useCaseId, int httpErrorCode, Throwable error, byte[] response) {}
+    public void onCallbackError(String useCaseId, int httpErrorCode, Throwable error, byte[] response) {
+    }
 
     private void sendEvent(String eventName, @Nullable WritableMap params) {
         final ReactInstanceManager instanceManager = ((ReactApplication) mContext).getReactNativeHost().getReactInstanceManager();

--- a/lib/YotiButton.android.js
+++ b/lib/YotiButton.android.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { NativeModules, NativeEventEmitter } from "react-native";
+import NativeComponent from "./NativeComponent";
 import RNYotiButton from "./NativeComponent";
 
 const nativeEvents = [
@@ -32,8 +33,27 @@ class YotiButton extends React.Component {
           if (nativeEventsToCommonProp.has(nativeEvent)) {
             propName = nativeEventsToCommonProp.get(nativeEvent);
           }
-          this.props.hasOwnProperty(propName) &&
+          if (this.props.hasOwnProperty(propName)) {
+            if (
+              event?.useCaseID &&
+              this.props?.useCaseID &&
+              event.useCaseID !== this.props.useCaseID
+            ) {
+              return;
+            }
+            if (nativeEvent === 'onCallbackReceived') {
+              const pattern = /(token=([^&]+))/;
+              const matches = pattern.exec(event?.url);
+              if (matches) {
+                const tokenFromURL = matches[2];
+                if (event?.token !== tokenFromURL) {
+                  event.token = decodeURIComponent(tokenFromURL);
+                }
+              }
+            }
+
             this.props[propName]({ nativeEvent: event });
+          }
         })
       );
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-button",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A <YotiButton /> component for React Native",
     "main": "YotiButton.js",
     "license": "MIT",


### PR DESCRIPTION
### Description

Register a single broadcast receiver, and unregister on destroy. Previously, each button instance would register its own broadcast.
This is not a problem for regular usage, but when multiple instances of the button are rendered on the same React component, the broadcast receivers are triggered which results in duplicate calls across the native bridge.

Filter events by useCaseID in Android native wrapper.
Events are sent across the bridge to every component.
Filter events by useCaseID when the useCaseID is available.
This ensures the component receives events relevant to it.

Extract token from URL when available.
The native SDK returns the same token in some instances, but the
callbackURL will have a unique token as expected.
Extract the token from the URL when it is available.

Bump version to 1.0.2.

### References

YM-23040

### Checklist

- [x] (N/A) I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
