### PR TITLE
[RELEASE][YM-26481] Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # ChangeLog
+## Version 2.1.1
 
-## Version 2.1.0
+Android 12 support
+
+## Version 2.1.0 - This version contains an issue on callbacks. Please jump to 2.1.1
 
 Android 12 support
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,14 +5,14 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
     buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 28)
-        versionCode 210
-        versionName "2.1.0"
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 31)
+        versionCode 211
+        versionName "2.1.1"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -22,5 +22,5 @@ android {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation "com.yoti.mobile.android.sdk:yoti-button-sdk:1.3.2"
+    implementation "com.yoti.mobile.android.sdk:yoti-button-sdk:1.3.4"
 }

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@getyoti/react-native-yoti-button",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "A <YotiButton /> component for React Native",
     "main": "YotiButton.js",
     "license": "MIT",


### PR DESCRIPTION
## Purpose
Fix SDK callbacks.

## External References (e.g. Jira / Zeplin / Confluence)
JIRA: [YM-26481](https://lampkicking.atlassian.net/browse/YM-26481)

## Approach
- Bump up Android Yoti Button SDK version to 1.3.4
- Bump up RN Yoti Button SDK version to 2.1.1

## Checklist
- Install apk attached to the ticket and use session data included in comments.
- Yoti Production account must be installed in the testing device.

- [x] Verify RN Yoti Button works for Android <12:
1. Install and run RN Android in the device.
2. Insert the test data and use CONTINUE WITH YOTI.
3. Yoti App will be opened.
4. Complete share.
5. Success callback is received.

- [x] Verify RN Yoti Button works for Android 12:
1. Install and run RN Android in the device.
2. Insert the test data and use CONTINUE WITH YOTI.
3. Yoti App will be opened.
4. Complete share.
5. Success callback is received.

- [x] QA Validation.

#### Tagged
@lampkicking/android-dev 